### PR TITLE
Enable course list extension to fix 500 error

### DIFF
--- a/apple-grader/Dockerfile
+++ b/apple-grader/Dockerfile
@@ -10,7 +10,8 @@ ENV NB_GID=100
 # enable nbgrader's create assignment and formgrader extensions
 RUN jupyter nbextension enable --sys-prefix create_assignment/main \
  && jupyter nbextension enable --sys-prefix formgrader/main --section=tree \
- && jupyter serverextension enable --sys-prefix nbgrader.server_extensions.formgrader
+ && jupyter serverextension enable --sys-prefix nbgrader.server_extensions.formgrader \
+ && jupyter serverextension enable --sys-prefix nbgrader.server_extensions.course_list
 
 # disable the assignment extension, since graders don't need it
 RUN jupyter nbextension disable --sys-prefix assignment_list/main --section=tree

--- a/apple-notebook/requirements.txt
+++ b/apple-notebook/requirements.txt
@@ -1,5 +1,5 @@
 https://github.com/IllumiDesk/async-nbgrader/archive/refs/tags/v0.3.1.zip
-https://github.com/IllumiDesk/formgradernext/archive/refs/tags/v0.3.2.zip
+https://github.com/IllumiDesk/formgradernext/archive/refs/tags/v0.3.3.zip
 jupyter-resource-usage>=0.6.0
 jupyter-server-proxy>=3.1.0
 nbgitpuller>=0.10.1


### PR DESCRIPTION
- Enables the course list extension which activates the `/formgraders` endpoint
- Fixes the Grader Console 500 error when the `/formgraders` path was not available